### PR TITLE
Fix strafe direction, harden gimbal recenter, and improve camera recovery

### DIFF
--- a/robowrap/camera.py
+++ b/robowrap/camera.py
@@ -63,6 +63,7 @@ class Camera:
         self._viewer_process: Optional[multiprocessing.Process] = None
         self._viewer_thread: Optional[threading.Thread] = None
         self._viewer_stop = threading.Event()
+        self._consecutive_frame_failures = 0
         self.pid = PID(-330, 0, -28, setpoint=0.0, sample_time=1.0 / self.frequency)
         self.pid.output_limits = (-self.follow_speed / 3.5 * 600, self.follow_speed / 3.5 * 600)
 
@@ -85,6 +86,7 @@ class Camera:
             return True
         result = self.camera.start_video_stream(display=False, resolution=self.resolution)
         self.streaming = bool(result is not False)
+        self._consecutive_frame_failures = 0
         return result
 
     def stop_detect(self) -> None:
@@ -101,7 +103,18 @@ class Camera:
             return True
         result = self.camera.stop_video_stream()
         self.streaming = False
+        self._consecutive_frame_failures = 0
         return result
+
+    def _recover_video_stream(self) -> bool:
+        if self.streaming:
+            try:
+                self.camera.stop_video_stream()
+            except Exception:
+                pass
+            self.streaming = False
+        result = self.start()
+        return bool(result is not False)
 
     def _draw_box(self, image: Any, start: tuple[int, int], end: tuple[int, int], color: tuple[int, int, int]) -> None:
         try:
@@ -138,9 +151,21 @@ class Camera:
     def frame(self, strategy: str = "newest", *, draw_debug: bool = True) -> Any:
         if not self.streaming:
             self.start()
-        image = self.camera.read_cv2_image(strategy=strategy)
+        try:
+            image = self.camera.read_cv2_image(strategy=strategy)
+        except Exception:
+            image = None
         if image is None:
-            return None
+            self._consecutive_frame_failures += 1
+            if self._consecutive_frame_failures >= 3 and self._recover_video_stream():
+                try:
+                    image = self.camera.read_cv2_image(strategy=strategy)
+                except Exception:
+                    image = None
+                self._consecutive_frame_failures = 0 if image is not None else self._consecutive_frame_failures
+            if image is None:
+                return None
+        self._consecutive_frame_failures = 0
         if draw_debug:
             self._draw_debug_items(image)
         return image
@@ -184,6 +209,9 @@ class Camera:
         self._viewer_thread = threading.Thread(target=self._viewer_worker, args=(fps,), daemon=True)
         self._viewer_thread.start()
         return True
+
+    def show(self, *args: Any, **kwargs: Any) -> Any:
+        return self.view(*args, **kwargs)
 
     def stop_view(self) -> None:
         self._viewer_stop.set()

--- a/robowrap/gun.py
+++ b/robowrap/gun.py
@@ -88,12 +88,23 @@ class Gun:
         pitch_speed: float = 100.0,
         yaw_speed: float = 100.0,
         blocking: bool = True,
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 8.0,
     ) -> Any:
         ensure_range("pitch_speed", pitch_speed, 0.0, 540.0, unit="degrees/second")
         ensure_range("yaw_speed", yaw_speed, 0.0, 540.0, unit="degrees/second")
         action = self.robot.gimbal.recenter(pitch_speed=pitch_speed, yaw_speed=yaw_speed)
-        return self.robomaster._complete_action(action, blocking=blocking, timeout=timeout)
+        result = self.robomaster._complete_action(action, blocking=blocking, timeout=timeout)
+        if not blocking or result is not False:
+            return result
+
+        # Some firmware/Wi-Fi combinations never report completion for gimbal.recenter().
+        fallback_action = self.robot.gimbal.moveto(
+            pitch=0.0,
+            yaw=0.0,
+            pitch_speed=pitch_speed,
+            yaw_speed=yaw_speed,
+        )
+        return self.robomaster._complete_action(fallback_action, blocking=blocking, timeout=timeout)
 
     def resume(self) -> Any:
         return self.robot.gimbal.resume()

--- a/robowrap/robowrap.py
+++ b/robowrap/robowrap.py
@@ -30,6 +30,8 @@ class RoboMaster:
         *,
         auto_reset: bool = True,
         default_mode: str = "chassis",
+        connect_retries: int = 2,
+        connect_retry_delay: float = 1.0,
         _sdk_robot: Optional[Any] = None,
         _sleep=sleep,
     ) -> None:
@@ -39,9 +41,26 @@ class RoboMaster:
 
         connection = self._normalize_connection_type(conn_type)
         ensure_choice("protocol", protocol.lower(), ("tcp", "udp"))
-        initialize_result = self.robot.initialize(conn_type=connection, proto_type=protocol.lower(), sn=serial)
+        ensure_int_range("connect_retries", connect_retries, 0, 20)
+        ensure_range("connect_retry_delay", connect_retry_delay, 0.0, 30.0, unit="seconds")
+
+        initialize_result: Any = False
+        initialize_error: Optional[Exception] = None
+        for attempt in range(connect_retries + 1):
+            try:
+                initialize_result = self.robot.initialize(conn_type=connection, proto_type=protocol.lower(), sn=serial)
+            except Exception as exc:
+                initialize_result = False
+                initialize_error = exc
+            if initialize_result is not False:
+                break
+            if attempt < connect_retries:
+                self.sleep(connect_retry_delay)
         if initialize_result is False:
-            raise RuntimeError("Robot could not be connected. Check power, network mode, and serial number.")
+            message = "Robot could not be connected. Check power, network mode, and serial number."
+            if initialize_error is not None:
+                message = f"{message} Last error: {initialize_error}"
+            raise RuntimeError(message)
 
         self.chassis = Chassis(self)
         self.gun = Gun(self)
@@ -291,10 +310,10 @@ class RoboMaster:
         return self.back(distance=distance, speed=speed, blocking=blocking)
 
     def left(self, distance: float = 0.5, *, speed: float = 1.0, blocking: bool = True) -> Any:
-        return self.move(y=distance, speed=speed, blocking=blocking)
+        return self.move(y=-distance, speed=speed, blocking=blocking)
 
     def right(self, distance: float = 0.5, *, speed: float = 1.0, blocking: bool = True) -> Any:
-        return self.move(y=-distance, speed=speed, blocking=blocking)
+        return self.move(y=distance, speed=speed, blocking=blocking)
 
     def circle(
         self,

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -157,3 +157,118 @@ class PublicApiTests(unittest.TestCase):
                 robot.cam.view()
         finally:
             camera_module.importlib.util.find_spec = original_find_spec
+
+    def test_left_right_map_to_expected_chassis_y_direction(self) -> None:
+        fake = FakeRobot()
+        robot = RoboMaster(_sdk_robot=fake, _sleep=lambda _: None)
+
+        robot.left(0.4)
+        left_call = fake.chassis.last_call()
+        robot.right(0.6)
+        right_call = fake.chassis.last_call()
+
+        self.assertEqual(left_call[0], "move")
+        self.assertEqual(left_call[2]["y"], -0.4)
+        self.assertEqual(right_call[0], "move")
+        self.assertEqual(right_call[2]["y"], 0.6)
+
+    def test_gun_recenter_uses_timeout_and_fallback_when_action_does_not_complete(self) -> None:
+        fake = FakeRobot()
+        robot = RoboMaster(_sdk_robot=fake, _sleep=lambda _: None)
+
+        class TimeoutAction:
+            def __init__(self) -> None:
+                self.timeout = None
+
+            def wait_for_completed(self, timeout=None):  # noqa: ANN001
+                self.timeout = timeout
+                return False
+
+        timeout_action = TimeoutAction()
+        fake.gimbal.recenter = lambda **kwargs: timeout_action  # type: ignore[method-assign]
+
+        robot.gun.recenter()
+
+        self.assertEqual(timeout_action.timeout, 8.0)
+        self.assertTrue(any(call[0] == "moveto" for call in fake.gimbal.calls))
+
+    def test_camera_show_alias_matches_view_dependency_behavior(self) -> None:
+        fake = FakeRobot()
+        robot = RoboMaster(_sdk_robot=fake, _sleep=lambda _: None)
+        import robowrap.camera as camera_module
+
+        original_find_spec = camera_module.importlib.util.find_spec
+
+        def fake_find_spec(name: str) -> object:
+            if name == "PySide6":
+                return None
+            return original_find_spec(name)
+
+        camera_module.importlib.util.find_spec = fake_find_spec
+        try:
+            with self.assertRaisesRegex(RuntimeError, "requires PySide6"):
+                robot.cam.show()
+        finally:
+            camera_module.importlib.util.find_spec = original_find_spec
+
+    def test_camera_frame_restarts_stream_after_repeated_read_failures(self) -> None:
+        fake = FakeRobot()
+        robot = RoboMaster(_sdk_robot=fake, _sleep=lambda _: None)
+        expected_frame = object()
+        read_count = {"n": 0}
+
+        def flaky_read(**kwargs):  # noqa: ANN003
+            read_count["n"] += 1
+            if read_count["n"] < 4:
+                raise RuntimeError("decoder error")
+            return expected_frame
+
+        fake.camera.read_cv2_image = flaky_read  # type: ignore[method-assign]
+
+        self.assertIsNone(robot.cam.frame())
+        self.assertIsNone(robot.cam.frame())
+        recovered = robot.cam.frame()
+
+        self.assertIs(recovered, expected_frame)
+        start_calls = [call for call in fake.camera.calls if call[0] == "start_video_stream"]
+        stop_calls = [call for call in fake.camera.calls if call[0] == "stop_video_stream"]
+        self.assertEqual(len(start_calls), 2)
+        self.assertEqual(len(stop_calls), 1)
+
+    def test_initialize_retries_then_succeeds(self) -> None:
+        fake = FakeRobot()
+        attempts = {"n": 0}
+
+        def flaky_initialize(**kwargs):  # noqa: ANN003
+            attempts["n"] += 1
+            return attempts["n"] >= 3
+
+        fake.initialize = flaky_initialize  # type: ignore[method-assign]
+        sleep_calls: list[float] = []
+
+        RoboMaster(_sdk_robot=fake, _sleep=lambda seconds: sleep_calls.append(seconds), connect_retries=3, connect_retry_delay=0.25)
+
+        self.assertEqual(attempts["n"], 3)
+        self.assertEqual(sleep_calls, [0.25, 0.25])
+
+    def test_initialize_retries_then_raises_runtime_error(self) -> None:
+        fake = FakeRobot()
+        attempts = {"n": 0}
+
+        def failing_initialize(**kwargs):  # noqa: ANN003
+            attempts["n"] += 1
+            return False
+
+        fake.initialize = failing_initialize  # type: ignore[method-assign]
+        sleep_calls: list[float] = []
+
+        with self.assertRaisesRegex(RuntimeError, "Robot could not be connected"):
+            RoboMaster(
+                _sdk_robot=fake,
+                _sleep=lambda seconds: sleep_calls.append(seconds),
+                connect_retries=2,
+                connect_retry_delay=0.1,
+            )
+
+        self.assertEqual(attempts["n"], 3)
+        self.assertEqual(sleep_calls, [0.1, 0.1])


### PR DESCRIPTION
## Summary
- Fix `left()` / `right()` strafing direction mapping.
- Harden `gun.recenter()` so it no longer hangs indefinitely by default:
  - bounded timeout (`8s` default)
  - fallback to `gimbal.moveto(0, 0)` if recenter completion is not reported.
- Improve camera robustness for decode/read failures:
  - add `cam.show()` alias for compatibility
  - add automatic stream restart + retry after repeated frame failures.
- Add constructor-level connection retry controls for unstable links (`connect_retries`, `connect_retry_delay`).
- Add regression tests for all of the above.

## Validation
- `python3 -m unittest -v tests.test_public_api` (pass)

## Related Issues
- Closes #1
- Closes #2
- Closes #3