### PR TITLE
Bump version to 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.8.5 - 2026-04-23
+
+- Fixed strafing direction so `left()` and `right()` map correctly to chassis motion.
+- Hardened `gun.recenter()` with a default timeout and a `moveto(0, 0)` fallback when completion is not reported.
+- Added `cam.show()` as a compatibility alias to `cam.view()`.
+- Added camera stream self-recovery in `cam.frame()` after repeated decode/read failures.
+- Added connection retry controls (`connect_retries`, `connect_retry_delay`) to improve reliability on unstable links.
+
 ## 0.8.4 - 2026-04-15
 
 - Updated the minimum SDK dependency to `robomaster-sdk-modern>=1.1.1.76`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robowrap"
-version = "0.8.4"
+version = "0.8.5"
 description = "A student-first wrapper around the DJI RoboMaster EP Python SDK."
 readme = "readme.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bump package version to `0.8.5` in `pyproject.toml`
- Add `0.8.5` changelog entry for the recently merged fixes

This unblocks release tag `v0.8.5` for PyPI publishing workflow.